### PR TITLE
Refactor the authentication mechanism

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,14 @@ import GuestOnlyRoute from "./components/auth/GuestOnlyRoute";
 const App = () => {
   return (
     <Routes>
-      <Route path="/" element={<Home />} />
+      <Route
+        path="/"
+        element={
+          <ProtectedRoute showNotLoggedInToast={false}>
+            <Home />
+          </ProtectedRoute>
+        }
+      />
       <Route
         path="/onboarding"
         element={

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -11,8 +11,7 @@ export default function LoginForm({
   className,
   ...props
 }: React.ComponentProps<"div">) {
-  // "!: Non-null Assertion"
-  const { login } = useContext(authContext)!;
+  const { login } = useContext(authContext);
   const { t } = useTranslation();
 
   return (

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -5,7 +5,7 @@ import { useCookies } from "react-cookie";
 import { jwtDecode } from "jwt-decode";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
-import { AccessTokenType } from "@/types/type";
+import { AccessToken } from "@/types/type";
 import { refreshAuthToken } from "@/lib/request/refreshAuthToken";
 import { authContext } from "@/lib/auth/authContext";
 
@@ -43,7 +43,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     ) => {
       setCookie("accessToken", accessToken, {
         path: "/",
-        expires: new Date(jwtDecode<AccessTokenType>(accessToken).exp * 1000),
+        expires: new Date(jwtDecode<AccessToken>(accessToken).exp * 1000),
       });
       setCookie("refreshToken", refreshToken, {
         path: "/",
@@ -88,7 +88,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       // calculate how long to update accessToken
       const timeUntilAccessTokenExpire = cookies.accessToken
         ? Math.min(
-            jwtDecode<AccessTokenType>(cookies.accessToken).exp * 1000 -
+            jwtDecode<AccessToken>(cookies.accessToken).exp * 1000 -
               Date.now() -
               60 * 1000,
             2147483647,

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -78,6 +78,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       );
       setAutoRefresh(data.refreshToken);
     },
+    onError: logout,
   });
 
   const setAutoRefresh = useCallback(

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -57,7 +57,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     removeCookie("accessToken", { path: "/" });
     removeCookie("refreshToken", { path: "/" });
     navigate("/login");
-    toast(t("authProvider.logoutToast"));
+    toast.info(t("authProvider.logoutToast"));
     clearTimers();
   }, [clearTimers, navigate, removeCookie, t]);
 

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -1,30 +1,26 @@
 import { useEffect, useCallback, ReactNode } from "react";
 import { useNavigate } from "react-router";
+import { useMutation } from "@tanstack/react-query";
 import { useCookies } from "react-cookie";
 import { jwtDecode } from "jwt-decode";
+import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 import { AccessTokenType } from "@/types/type";
 import { refreshAuthToken } from "@/lib/request/refreshAuthToken";
 import { authContext } from "@/lib/auth/authContext";
-import { toast } from "sonner";
 
-let accessTimer: number;
+let refreshTimer: number;
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const navigate = useNavigate();
   const { t } = useTranslation();
-
   const [cookies, setCookie, removeCookie] = useCookies([
     "accessToken",
-    "refreshTokenExpirationTime",
     "refreshToken",
   ]);
 
-  const accessToken = cookies.accessToken || null;
-  const refreshToken = cookies.refreshToken || null;
-
   const clearTimers = useCallback(() => {
-    clearTimeout(accessTimer);
+    clearTimeout(refreshTimer);
   }, []);
 
   const login = useCallback((provider: "google" | "nycu") => {
@@ -39,90 +35,86 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     window.location.href = urlMap[provider];
   }, []);
 
+  const setCookiesForAuthToken = useCallback(
+    (
+      accessToken: string,
+      refreshToken: string,
+      refreshTokenExpirationTime: number = Date.now() + 60 * 60 * 24 * 1000,
+    ) => {
+      setCookie("accessToken", accessToken, {
+        path: "/",
+        expires: new Date(jwtDecode<AccessTokenType>(accessToken).exp * 1000),
+      });
+      setCookie("refreshToken", refreshToken, {
+        path: "/",
+        expires: new Date(refreshTokenExpirationTime),
+      });
+    },
+    [setCookie],
+  );
+
   const logout = useCallback(() => {
     removeCookie("accessToken", { path: "/" });
-    removeCookie("refreshTokenExpirationTime", { path: "/" });
     removeCookie("refreshToken", { path: "/" });
-    clearTimers();
-    navigate("login");
+    navigate("/login");
     toast(t("authProvider.logoutToast"));
+    clearTimers();
   }, [clearTimers, navigate, removeCookie, t]);
 
   const isLoggedIn = useCallback(() => {
-    if (cookies.accessToken) {
+    if (cookies.refreshToken) {
       return true;
     }
     return false;
-  }, [cookies.accessToken]);
+  }, [cookies.refreshToken]);
+
+  const refreshMutation = useMutation({
+    mutationFn: (refreshToken: string) => refreshAuthToken(refreshToken),
+    onSuccess: (data) => {
+      setCookiesForAuthToken(
+        data.accessToken,
+        data.refreshToken,
+        data.refreshTokenExpirationTime * 1000,
+      );
+      setAutoRefresh(data.refreshToken);
+    },
+  });
 
   const setAutoRefresh = useCallback(
-    (accessToken: string, refreshToken: string) => {
+    (refreshToken: string) => {
       clearTimers();
-      // get accessToken Expiration time
-      const accessExpirationTime =
-        jwtDecode<AccessTokenType>(accessToken).exp * 1000;
 
       // calculate how long to update accessToken
-      const timeUntilAccessExpiration = Math.min(
-        accessExpirationTime - Date.now() - 60 * 1000,
-        2147483647,
-      );
+      const timeUntilAccessTokenExpire = cookies.accessToken
+        ? Math.min(
+            jwtDecode<AccessTokenType>(cookies.accessToken).exp * 1000 -
+              Date.now() -
+              60 * 1000,
+            2147483647,
+          )
+        : 0;
 
       // set a timer to update both token
-      if (timeUntilAccessExpiration > 0) {
-        accessTimer = window.setTimeout(async () => {
-          const data = await refreshAuthToken(refreshToken);
-          if (!data) {
-            logout();
-            return;
-          }
-          setCookie("accessToken", data.accessToken, { path: "/" });
-          setCookie("refreshTokenExpirationTime", data.expirationTime, {
-            path: "/",
-          });
-          setCookie("refreshToken", data.refreshToken, { path: "/" });
-        }, timeUntilAccessExpiration);
-      } else {
-        // assume user haven't open the clustron website for a long time so timeUntilAccessExpiration < 0
-        // it need to update both token immediately
-        (async () => {
-          const data = await refreshAuthToken(refreshToken);
-          if (!data) {
-            logout();
-            return;
-          }
-          setCookie("accessToken", data.accessToken, { path: "/" });
-          setCookie("refreshTokenExpirationTime", data.expirationTime, {
-            path: "/",
-          });
-          setCookie("refreshToken", data.refreshToken, { path: "/" });
-        })();
-      }
-
-      // calculate how long does refreshToken expired
-      const refreshExpirationTime = cookies.refreshTokenExpirationTime;
-      if (refreshExpirationTime) {
-        const timeUntilRefreshExpiration = Math.min(
-          refreshExpirationTime * 1000 - Date.now(),
-          2147483647,
-        );
-        if (timeUntilRefreshExpiration < 0) {
-          logout();
+      refreshTimer = window.setTimeout(async () => {
+        if (!refreshMutation.isPending) {
+          refreshMutation.mutate(refreshToken);
         }
-      }
+      }, timeUntilAccessTokenExpire);
     },
-    [clearTimers, cookies.refreshTokenExpirationTime, logout, setCookie],
+    [clearTimers, cookies.accessToken, refreshMutation],
   );
 
   useEffect(() => {
-    if (accessToken && refreshToken) {
-      setAutoRefresh(accessToken, refreshToken);
+    if (cookies.refreshToken) {
+      setAutoRefresh(cookies.refreshToken);
     }
     return () => clearTimers();
-  }, [accessToken, refreshToken, setAutoRefresh, clearTimers]);
+  }, [cookies.refreshToken, setAutoRefresh, clearTimers]);
 
   return (
-    <authContext.Provider value={{ login, logout, isLoggedIn }}>
+    <authContext.Provider
+      value={{ login, setCookiesForAuthToken, logout, isLoggedIn }}
+    >
       {children}
     </authContext.Provider>
   );

--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -1,20 +1,29 @@
 import { useContext, useEffect, ReactNode } from "react";
-import { useNavigate } from "react-router";
+import { useNavigate, useLocation } from "react-router";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 import { authContext } from "@/lib/auth/authContext";
 
-export default function ProtectedRoute({ children }: { children: ReactNode }) {
+export default function ProtectedRoute({
+  children,
+  showNotLoggedInToast = true,
+}: {
+  children: ReactNode;
+  showNotLoggedInToast?: boolean;
+}) {
   const { isLoggedIn } = useContext(authContext);
   const navigate = useNavigate();
+  const location = useLocation();
   const { t } = useTranslation();
 
   useEffect(() => {
-    if (!isLoggedIn()) {
+    if (!isLoggedIn() && window.location.pathname !== "/login") {
       navigate("/login");
-      toast.warning(t("protectedRoute.notLoggedInToast"));
+      if (showNotLoggedInToast) {
+        toast.warning(t("protectedRoute.notLoggedInToast"));
+      }
     }
-  }, [isLoggedIn, navigate, t]);
+  }, [showNotLoggedInToast, isLoggedIn, navigate, location, t]);
 
   if (!isLoggedIn()) return null;
 

--- a/src/lib/auth/authContext.ts
+++ b/src/lib/auth/authContext.ts
@@ -2,6 +2,11 @@ import { createContext } from "react";
 
 type AuthContextType = {
   login: (provider: "google" | "nycu") => void;
+  setCookiesForAuthToken: (
+    accessToken: string,
+    refreshToken: string,
+    refreshTokenExpirationTime?: number,
+  ) => void;
   logout: () => void;
   isLoggedIn: () => boolean;
 };
@@ -9,6 +14,10 @@ type AuthContextType = {
 export const authContext = createContext<AuthContextType>({
   login: () => {
     console.warn("login() called without provider");
+  },
+
+  setCookiesForAuthToken: () => {
+    console.warn("setCookiesForAuthToken() called without provider");
   },
 
   logout: () => {

--- a/src/lib/request/refreshAuthToken.ts
+++ b/src/lib/request/refreshAuthToken.ts
@@ -1,10 +1,11 @@
 export async function refreshAuthToken(refreshToken: string): Promise<{
   accessToken: string;
-  expirationTime: number;
   refreshToken: string;
-} | null> {
+  refreshTokenExpirationTime: number;
+}> {
   if (!refreshToken) {
-    return null;
+    console.error("Failed to refresh auth token due to no refreshtoken");
+    throw new Error();
   }
 
   const res = await fetch(`/api/refreshToken/${refreshToken}`, {
@@ -15,12 +16,14 @@ export async function refreshAuthToken(refreshToken: string): Promise<{
   });
 
   if (!res.ok) {
-    return null;
+    console.error("Failed to refresh auth token due to response error");
+    throw new Error();
   }
+
   const data = await res.json();
   return {
     accessToken: data.accessToken,
-    expirationTime: data.expirationTime,
     refreshToken: data.refreshToken,
+    refreshTokenExpirationTime: data.expirationTime,
   };
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,22 +4,27 @@ import { BrowserRouter } from "react-router-dom";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { CookiesProvider } from "react-cookie";
 import { AuthProvider } from "@/components/auth/AuthProvider";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "./index.css";
 import App from "./App.tsx";
 import "./i18n";
 import { Toaster } from "@/components/ui/sonner";
 
+const queryClient = new QueryClient();
+
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <BrowserRouter>
-      <CookiesProvider>
-        <AuthProvider>
-          <ThemeProvider defaultTheme="light" storageKey="vite-ui-theme">
-            <Toaster />
-            <App />
-          </ThemeProvider>
-        </AuthProvider>
-      </CookiesProvider>
+      <QueryClientProvider client={queryClient}>
+        <CookiesProvider>
+          <AuthProvider>
+            <ThemeProvider defaultTheme="light" storageKey="vite-ui-theme">
+              <Toaster />
+              <App />
+            </ThemeProvider>
+          </AuthProvider>
+        </CookiesProvider>
+      </QueryClientProvider>
     </BrowserRouter>
   </StrictMode>,
 );

--- a/src/pages/Callback.tsx
+++ b/src/pages/Callback.tsx
@@ -3,7 +3,7 @@ import { jwtDecode } from "jwt-decode";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { useNavigate, useLocation } from "react-router";
-import { AccessTokenType } from "@/types/type";
+import { AccessToken } from "@/types/type";
 import { authContext } from "@/lib/auth/authContext";
 
 export default function Callback() {
@@ -27,7 +27,7 @@ export default function Callback() {
     setCookiesForAuthToken(accessToken, refreshToken);
 
     let redirectTo;
-    if (jwtDecode<AccessTokenType>(accessToken).Role === "ROLE_NOT_SETUP") {
+    if (jwtDecode<AccessToken>(accessToken).Role === "ROLE_NOT_SETUP") {
       redirectTo = "/onboading";
     } else {
       redirectTo = "/";

--- a/src/pages/Callback.tsx
+++ b/src/pages/Callback.tsx
@@ -1,19 +1,15 @@
-import { useEffect } from "react";
-import { useCookies } from "react-cookie";
+import { useContext, useEffect } from "react";
 import { jwtDecode } from "jwt-decode";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { useNavigate, useLocation } from "react-router";
 import { AccessTokenType } from "@/types/type";
+import { authContext } from "@/lib/auth/authContext";
 
 export default function Callback() {
-  const [, setCookie] = useCookies([
-    "accessToken",
-    "refreshTokenExpirationTime",
-    "refreshToken",
-  ]);
   const navigate = useNavigate();
   const location = useLocation();
+  const { setCookiesForAuthToken } = useContext(authContext);
   const { t } = useTranslation();
 
   useEffect(() => {
@@ -28,13 +24,7 @@ export default function Callback() {
       return;
     }
 
-    setCookie("accessToken", accessToken, { path: "/" });
-    setCookie("refreshToken", refreshToken, { path: "/" });
-    setCookie(
-      "refreshTokenExpirationTime",
-      Math.floor(Date.now() / 1000) + 1 * 24 * 60 * 60,
-      { path: "/" },
-    );
+    setCookiesForAuthToken(accessToken, refreshToken);
 
     let redirectTo;
     if (jwtDecode<AccessTokenType>(accessToken).Role === "ROLE_NOT_SETUP") {
@@ -45,7 +35,7 @@ export default function Callback() {
 
     navigate(redirectTo);
     toast.success(t("callback.loginSuccessToast"));
-  }, [navigate, location, setCookie, t]);
+  }, [navigate, setCookiesForAuthToken, location, t]);
 
   return <div className="min-h-screen">{t("callback.loadingMessage")}</div>;
 }

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -1,4 +1,4 @@
-export type AccessTokenType = {
+export type AccessToken = {
   ID: string;
   Username: string;
   Email: string;


### PR DESCRIPTION
## Types of Change  
- Refactor

## Purpose
Primarily Address the issue where the authentication cookie would be removed when the user closed the browser. It also includes several code optimizations:

- Redirect users to the login page if they access the homepage without being authenticated by applying `ProtectedRoute` to home.
- Refactor the token refresh flow using `@tanstack/react-query` to manage access token and refresh token updates more cleanly.
- Add `setCookiesForAuthToken` to `authContext` for the callback page to reuse the logic for setting authentication cookies.
- Add an expire field to cookies to persist across browser restarts, and store the refresh token's expiration time in the cookie itself.
- Remove the conditional check for `timeUntilAccessTokenExpire > 0`, since `setTimeout` can safely accept negative values.
- Remove unnecessary logic for manually calculating `refreshExpirationTime` and `timeUntilRefreshExpiration`, since cookie expiration now handles it automatically.
- Use the presence of the refresh token instead of the access token to determine login status.

