### PR TITLE
Fix loading effect after saving onboarding info

### DIFF
--- a/src/components/OnboardingForm.tsx
+++ b/src/components/OnboardingForm.tsx
@@ -30,15 +30,16 @@ export default function OnboardingForm({
   const { t } = useTranslation();
 
   const addMutation = useMutation({
-    mutationFn: (payload: { username: string; linuxUsername: string }) =>
-      saveOnboardingInfo(payload),
+    mutationFn: async (payload: {
+      username: string;
+      linuxUsername: string;
+    }) => {
+      await saveOnboardingInfo(payload);
+      await refreshMutation.mutateAsync();
+    },
     onSuccess: () => {
-      // TODO: Come up with a better way to handle navigate after refresh instead of setTimeout
-      refreshMutation.mutate();
-      setTimeout(() => {
-        navigate("/");
-        toast.success(t("onboardingForm.successToast"));
-      }, 2000);
+      navigate("/");
+      toast.success(t("onboardingForm.successToast"));
     },
     onError: () => {
       toast.error(t("onboardingForm.saveFailToast"));


### PR DESCRIPTION
## Type of changes

- Fix

## Purpose

- Replace `useState` with `useRef` for immediate token/role updates and ensure latest token values are used for route protection logic
- Remove redundant setTimeout after onboarding save operation as direct navigation works correctly with immediate ref update
