### PR TITLE
Correct property name in group role type

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,1 @@
-VITE_BACKEND_BASE_URL=https://api.dev.clustron.sdc.nycu.club
+VITE_BACKEND_BASE_URL=http://localhost:8080

--- a/src/hooks/useRoleMapper.ts
+++ b/src/hooks/useRoleMapper.ts
@@ -8,7 +8,10 @@ export function useRoleMapper() {
     // console.log("roleNameToId", name, roles);
     // console.log(r.role, name.role.roleName)
     console.log("Roles from useGroupRoles:", roles);
-    return roles.find((r) => r.Role === name)?.ID;
+    console.log("Looking for role:", name);
+    const id = roles.find((r) => r.roleName === name)?.id;
+    console.log(id);
+    return id;
   };
 
   return {

--- a/src/pages/AddMemberPage.tsx
+++ b/src/pages/AddMemberPage.tsx
@@ -59,6 +59,7 @@ export default function AddMemberPage() {
   const handleSave = () => {
     const newMembers = members.map((m) => {
       const roleId = roleNameToId(m.roleName);
+      console.log("roleNameToId", m.roleName, roleId);
       if (!roleId) throw new Error(`Invalid roleName: ${m.roleName}`);
       return {
         member: m.id.trim(),

--- a/src/pages/CreateGroup.tsx
+++ b/src/pages/CreateGroup.tsx
@@ -50,6 +50,7 @@ export default function AddGroupPage() {
   const handleSave = () => {
     const newMembers = members.map((m) => {
       const roleId = roleNameToId(m.roleName);
+      console.log("roleNameToId", m.roleName, roleId);
       if (!roleId) throw new Error(`Invalid role: ${m.roleName}`);
       return {
         member: m.id.trim(),

--- a/src/types/group.ts
+++ b/src/types/group.ts
@@ -20,8 +20,8 @@ export type GroupMemberRoleName =
 
 // group role
 export type GroupRole = {
-  ID: string;
-  Role: GroupMemberRoleName;
+  id: string;
+  roleName: GroupMemberRoleName;
   accessLevel: GroupRoleAccessLevel;
 };
 // group member


### PR DESCRIPTION
## Type of changes

- Fix

## Purpose

- Correct the property name in group role type to fit the api spec and prevent undefined behavior.

## Additional information
The correct GroupRole data type is as follow
```
export type GroupRole = {
  id: string;
  roleName: GroupMemberRoleName;
  accessLevel: GroupRoleAccessLevel;
};
```