### PR TITLE
[CLUST-109] Fix MemberDeleteButton 'onConfirm' prop type

### DIFF
--- a/src/components/group/MemberDeleteMenu.tsx
+++ b/src/components/group/MemberDeleteMenu.tsx
@@ -19,7 +19,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 type Props = {
-  onConfirm: () => Promise<void> | void;
+  onConfirm: () => void;
   isArchived?: boolean;
 };
 
@@ -32,7 +32,7 @@ export default function MemberDeleteMenu({ onConfirm, isArchived }: Props) {
     if (isArchived) return;
     setIsPending(true);
     try {
-      await onConfirm();
+      onConfirm();
       setOpen(false);
     } finally {
       setIsPending(false);


### PR DESCRIPTION
## Type of changes

- Fix

## Purpose

- Remove `Promise` return type from `onConfirm()` since it is not utilized by its callers