### PR TITLE
Change `npm run dev` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,4 @@ dist-ssr
 *.sw?
 
 .env
-.env.local
+.env.devlocal

--- a/example.env
+++ b/example.env
@@ -1,4 +1,4 @@
 # This is an example .env file for a Vite project.
-# npm run dev will run with .env.local
+# npm run dev will run with .env.devlocal
 
 VITE_BACKEND_BASE_URL=http://localhost:8080

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite --mode local",
+    "dev": "vite --mode devlocal",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",


### PR DESCRIPTION
## Type of changes

- Fix

## Purpose

- Change `npm run dev` command from `vite --mode local` to `vite --mode devlocal` in order to prevent naming conflict with vite keyword
- Rename local environment file from `.env.local` to `.env.devlocal` to match the vite execution mode.
