### PR TITLE
Use the normalizeUrl function to normalize the newly added URL to ensure it contains protocol

### DIFF
--- a/src/pages/group/CreateGroup.tsx
+++ b/src/pages/group/CreateGroup.tsx
@@ -118,7 +118,7 @@ export default function AddGroupPage() {
     const linksToSubmit: GroupLinkPayload[] = [
       ...links,
       ...(newLink.title.trim() && newLink.url.trim()
-        ? [{ title: newLink.title.trim(), url: newLink.url.trim() }]
+        ? [{ title: newLink.title.trim(), url: normalizeUrl(newLink.url) }]
         : []),
     ]
       .filter((l) => l.title.trim() && l.url.trim())


### PR DESCRIPTION
## Type of changes

- Fix

## Purpose

- Resolve the issue that a URL will contain no protocol (http, https) and cause the link to not navigate to an external website.
- Apply the normalize function to the `newlink` before sending the request to the backend.

## Additional Information

Original bug: 
The normalize function is applied when the user presses the `add` button for the link. But the latest likes will not be normalized. As a result, the latest will be sent to the backend without a proper URL format.