### PR TITLE
[CLUST-204] Remove type declarations from useQuery and useMutation

### DIFF
--- a/src/hooks/useCreateGroup.ts
+++ b/src/hooks/useCreateGroup.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createGroup } from "@/lib/request/createGroup";
-import type { CreateGroupInput, CreateGroupResponse } from "@/types/group";
+import type { CreateGroupResponse } from "@/types/group";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 
@@ -12,7 +12,7 @@ export function useCreateGroup(options?: {
   const { t } = useTranslation();
   const toastId = "create-group";
 
-  return useMutation<CreateGroupResponse, Error, CreateGroupInput>({
+  return useMutation({
     mutationFn: createGroup,
     onMutate: () => {
       toast.loading(t("groupPages.createGroup.creatingToast", "Creating..."), {

--- a/src/hooks/useGetGroupById.ts
+++ b/src/hooks/useGetGroupById.ts
@@ -1,9 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { getGroupById } from "@/lib/request/getGroupById";
-import type { GroupDetail } from "@/types/group";
 
 export function useGetGroupById(id: string, enabled = true) {
-  return useQuery<GroupDetail>({
+  return useQuery({
     queryKey: ["group", id],
     queryFn: () => getGroupById(id),
     enabled: !!id && enabled,

--- a/src/hooks/useGetGroups.ts
+++ b/src/hooks/useGetGroups.ts
@@ -1,9 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { getGroups } from "@/lib/request/getGroups";
-import type { GetGroupsResponse } from "@/types/group";
 
 export function useGetGroups() {
-  return useQuery<GetGroupsResponse>({
+  return useQuery({
     queryKey: ["groups"],
     queryFn: getGroups,
   });

--- a/src/hooks/useGetMembers.ts
+++ b/src/hooks/useGetMembers.ts
@@ -1,9 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { getMembers } from "@/lib/request/getMembers";
-import type { GetGroupMembersResponse } from "@/types/group";
 
 export function useGetMembers(groupId: string, page: number = 1) {
-  return useQuery<GetGroupMembersResponse>({
+  return useQuery({
     queryKey: ["GroupMember", groupId, page],
     queryFn: () => getMembers(groupId, page),
     enabled: !!groupId,

--- a/src/hooks/useGetPendingMembers.ts
+++ b/src/hooks/useGetPendingMembers.ts
@@ -1,9 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { getPendingMembers } from "@/lib/request/groupPendingMembers";
-import type { GetPendingMembersResponse } from "@/types/group";
 
 export function useGetPendingMembers(groupId: string, page: number = 0) {
-  return useQuery<GetPendingMembersResponse>({
+  return useQuery({
     queryKey: ["pendingMembers", groupId, page],
     queryFn: () => getPendingMembers(groupId, page),
     enabled: !!groupId,

--- a/src/hooks/useGroupLinks.ts
+++ b/src/hooks/useGroupLinks.ts
@@ -1,10 +1,8 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createGroupLink } from "@/lib/request/groupLinks";
-import type { GroupLinkPayload, GroupLinkResponse } from "@/types/group";
+import type { GroupLinkResponse } from "@/types/group";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
-
-type Vars = { groupId: string; payload: GroupLinkPayload };
 
 export function useCreateGroupLink(options?: {
   onSuccess?: (data: GroupLinkResponse) => void;
@@ -13,7 +11,7 @@ export function useCreateGroupLink(options?: {
   const qc = useQueryClient();
   const { t } = useTranslation();
 
-  return useMutation<GroupLinkResponse, Error, Vars, string>({
+  return useMutation({
     mutationFn: createGroupLink,
     mutationKey: ["GroupLinks", "create"],
     onMutate: (vars) => {

--- a/src/hooks/useRemoveMember.ts
+++ b/src/hooks/useRemoveMember.ts
@@ -16,7 +16,7 @@ export function useRemoveMember(
   const queryClient = useQueryClient();
   const { t } = useTranslation();
 
-  return useMutation<void, unknown, string, string>({
+  return useMutation({
     mutationFn: (memberId: string) => removeMember(groupId, memberId),
     onMutate: (memberId) => {
       const toastId = `remove-member-${groupId}-${memberId}`;

--- a/src/hooks/useRemovePendingMember.ts
+++ b/src/hooks/useRemovePendingMember.ts
@@ -8,7 +8,7 @@ export function useRemovePendingMember(groupId: string) {
   const queryClient = useQueryClient();
   const { t } = useTranslation();
 
-  return useMutation<void, Error, RemovePendingMemberParams, string>({
+  return useMutation({
     mutationFn: (params: RemovePendingMemberParams) =>
       removePendingMember(params),
     onMutate: (params) => {

--- a/src/hooks/useRoleMapper.ts
+++ b/src/hooks/useRoleMapper.ts
@@ -17,7 +17,7 @@ export function useRoleMapper() {
     data = [] as GroupRole[],
     isLoading,
     isError,
-  } = useQuery<GroupRole[]>({
+  } = useQuery({
     queryKey: ["roles"],
     queryFn: fetchRoles,
   });

--- a/src/hooks/useTransferGroupOwner.ts
+++ b/src/hooks/useTransferGroupOwner.ts
@@ -17,7 +17,7 @@ export function useTransferGroupOwner(
 ) {
   const { t } = useTranslation();
 
-  return useMutation<unknown, Error, TransferGroupOwnershipRequest, string>({
+  return useMutation({
     ...options,
 
     mutationFn: (data: TransferGroupOwnershipRequest) =>

--- a/src/hooks/useUnarchiveGroup.ts
+++ b/src/hooks/useUnarchiveGroup.ts
@@ -15,7 +15,7 @@ export function useUnarchiveGroup(
   const queryClient = useQueryClient();
   const { t } = useTranslation();
 
-  return useMutation<unknown, Error, void, string>({
+  return useMutation({
     mutationFn: () => unarchiveGroup(groupId),
     onMutate: () => {
       const toastId = `unarchive-group-${groupId}`;


### PR DESCRIPTION
## Type of changes

- Refactor

## Purpose

- Currently there are many useQuery and useMutation hook including type declaration, but some of them are not correct. Remove manual type declaration and let TypeScript infer the data type would be more precise.
- Remove type declarations from useQuery and useMutation

<!-- Provide a brief description of the changes made in this pull request. -->