### PR TITLE
Fix the mismatched link in AdminLayout and JobLayout which lead to an incorrect route

### DIFF
--- a/src/pages/layouts/AdminLayout.tsx
+++ b/src/pages/layouts/AdminLayout.tsx
@@ -26,7 +26,7 @@ export default function AdminLayout() {
 
   const adminNavItems: NavItem[] = [
     {
-      to: "/admin/role-access",
+      to: "/admin/config",
       label: t("adminSidebar.roleAccessConfigLink"),
     },
   ];

--- a/src/pages/layouts/JobLayout.tsx
+++ b/src/pages/layouts/JobLayout.tsx
@@ -7,11 +7,11 @@ export default function JobLayout() {
 
   const jobNavItems: NavItem[] = [
     {
-      to: `/joblist`,
+      to: `/jobs`,
       label: t("jobsSideBar.ListNavLink"),
     },
     {
-      to: `/jobform`,
+      to: `/jobs/submit`,
       label: t("jobsSideBar.SubmitNavLink"),
     },
   ];


### PR DESCRIPTION
## Type of changes

- Fix

## Purpose

- Fix the mismatched link in AdminLayout and JobLayout which lead to an incorrect route causing blank pages.
