### PR TITLE
[CLUST-220] Fix pending member table title display text

### DIFF
--- a/src/components/group/PendingMemberTable.tsx
+++ b/src/components/group/PendingMemberTable.tsx
@@ -85,7 +85,9 @@ export default function PendingMemberTable({
     <Card>
       <CardContent className="p-6">
         <div className="flex justify-between items-center mb-4">
-          <h3 className="font-bold text-lg">{t("groupPages.pendingMember")}</h3>
+          <h3 className="font-bold text-lg">
+            {t("groupPages.pendingMembers.pendingMember")}
+          </h3>
         </div>
 
         {isLoading ? (


### PR DESCRIPTION
## Type of changes

- Fix

## Purpose

- In group page, the titles of the pending member table are not correctly displayed.
- Update pending member table title text to the correct wording.
