### PR TITLE
Remove .env.devlocal to ignore local environment variable from version control

### DIFF
--- a/.env.devlocal
+++ b/.env.devlocal
@@ -1,1 +1,0 @@
-VITE_BACKEND_BASE_URL=https://api.dev.clustron.sdc.nycu.club


### PR DESCRIPTION
## Type of changes

- Chore

## Purpose

- Remove .env.devlocal to ignore local environment variable from version control
- Prevent unnecessary diff.
