### PR TITLE
[CLUST-252] User can still visit onboarding page

### DIFF
--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -51,6 +51,14 @@ export default function ProtectedRoute({
       toast.warning(t("protectedRoute.roleNotSetupToast"));
       return;
     }
+
+    if (
+      role.current != "role_not_setup" &&
+      window.location.pathname == "/onboarding"
+    ) {
+      navigate("/");
+      return;
+    }
   }, [showLoginRequiredToast, isLoggedIn, navigate, t]);
 
   if (
@@ -58,7 +66,10 @@ export default function ProtectedRoute({
     !isLoggedIn() ||
     // logged in and role is not set up but go to protected page
     (role.current == "role_not_setup" &&
-      window.location.pathname != "/onboarding")
+      window.location.pathname != "/onboarding") ||
+    // logged in and role is set up but go to onboarding page
+    (role.current != "role_not_setup" &&
+      window.location.pathname == "/onboarding")
   ) {
     return null;
   }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,12 +11,35 @@ import { Toaster } from "@/components/ui/sonner";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ErrorBoundary } from "react-error-boundary";
 import ErrorFallBack from "@/components/ErrorFallBack";
+import { useEffect } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 
 const queryClient = new QueryClient();
+
+/**
+ * Normalizes URL path to lowercase.
+ * While React Router is case-insensitive, URLs should be treated as case-sensitive
+ * for consistency. Redirects use { replace: true } to avoid breaking browser history.
+ * Reference: https://developers.google.com/search/docs/crawling-indexing/url-structure
+ */
+
+const CaseNormalization = () => {
+  const { pathname, search } = useLocation();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (/[A-Z]/.test(pathname)) {
+      navigate(pathname.toLowerCase() + search, { replace: true });
+    }
+  }, [pathname, navigate, search]);
+
+  return null;
+};
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <BrowserRouter>
+      <CaseNormalization />
       <QueryClientProvider client={queryClient}>
         <CookiesProvider>
           <AuthProvider>


### PR DESCRIPTION
## Type of changes

- fix

## Purpose

- Resolve issue https://github.com/NYCU-SDC/clustron-api/issues/56

## Additional Information

Update ProtectedRoute to prevent manual URL navigation to onboarding after login, and force lowercase URL paths to ensure routing consistency. 

According to the [Google Search Center](https://developers.google.com/search/docs/crawling-indexing/url-structure#:~:text=Be%20aware%20that%20URLs%20are%20case%20sensitive), we should be aware that URLs are case sensitive; therefore, we normalize paths even though React Router is case-insensitive. 

