### PR TITLE
Remove mistaken condition to allow user to create a group without initial members

### DIFF
--- a/src/pages/group/CreateGroup.test.tsx
+++ b/src/pages/group/CreateGroup.test.tsx
@@ -248,7 +248,6 @@ describe("CreateGroup", () => {
 
       await user.type(titleInput, "Test Group");
       await user.type(descriptionInput, "Test Description");
-      await user.type(screen.getByTestId("member-id-0"), "student@example.com");
 
       const buttons = screen.getAllByRole("button");
       const createButton = buttons.find((btn) =>

--- a/src/pages/group/CreateGroup.tsx
+++ b/src/pages/group/CreateGroup.tsx
@@ -141,7 +141,6 @@ export default function AddGroupPage() {
     (m, i) =>
       members.findIndex((other) => other.id.trim() === m.id.trim()) !== i,
   );
-  const hasEmptyId = members.some((m) => !m.id.trim());
 
   const handleAddBatch = (
     newMembers: { id: string; roleName: GroupMemberRoleName }[],
@@ -357,7 +356,6 @@ export default function AddGroupPage() {
           onClick={handleSave}
           disabled={
             hasDuplicate ||
-            hasEmptyId ||
             !title.trim() ||
             createGroup.isPending ||
             !description.trim()


### PR DESCRIPTION
## Type of changes

- Fix

## Purpose

- Remove `hasEmptyId` condition in `CreateGroupPage`, which disabled the create button when no members were added.
- Allow the user to create a group without initial members is the original design.

<!-- Provide a brief description of the changes made in this pull request. -->

## Additional Information

This comes from PR NYCU-SDC/clustron-frontend#127. Accidentally adding an extra condition and break the varification logic.
<!-- Optional: Add any other information that would be helpful for the reviewer. Like detail spec, decisions, trade-offs, links, etc. -->
