### PR TITLE
fix: fix side bar text truncation and apply i18n in Layout testing

### DIFF
--- a/src/pages/layouts/AdminLayout.test.tsx
+++ b/src/pages/layouts/AdminLayout.test.tsx
@@ -1,3 +1,4 @@
+vi.unmock("react-i18next");
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, vi, beforeEach, expect } from "vitest";
@@ -10,6 +11,8 @@ import { AuthProvider } from "@/components/auth/AuthProvider";
 import AdminLayout from "./AdminLayout";
 import App from "@/App";
 import type * as ReactCookie from "react-cookie";
+import i18n from "@/i18n";
+import { I18nextProvider } from "react-i18next";
 
 vi.mock("react-cookie", async () => {
   const mod = await vi.importActual<typeof ReactCookie>("react-cookie");
@@ -36,8 +39,9 @@ vi.mock("@/lib/request/getUsers", () => ({
 }));
 
 describe("AdminLayout", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
+    await i18n.changeLanguage("en");
   });
 
   function renderAdminLayout(initialRoute = "/admin/config") {
@@ -53,16 +57,18 @@ describe("AdminLayout", () => {
     vi.mocked(getAccessToken).mockReturnValue("mock-token");
 
     return render(
-      <QueryClientProvider client={queryClient}>
-        <CookiesProvider>
-          <MemoryRouter initialEntries={[initialRoute]}>
-            <AuthProvider>
-              <AdminLayout />
-              <App />
-            </AuthProvider>
-          </MemoryRouter>
-        </CookiesProvider>
-      </QueryClientProvider>,
+      <I18nextProvider i18n={i18n}>
+        <QueryClientProvider client={queryClient}>
+          <CookiesProvider>
+            <MemoryRouter initialEntries={[initialRoute]}>
+              <AuthProvider>
+                <AdminLayout />
+                <App />
+              </AuthProvider>
+            </MemoryRouter>
+          </CookiesProvider>
+        </QueryClientProvider>
+      </I18nextProvider>,
     );
   }
 
@@ -72,7 +78,7 @@ describe("AdminLayout", () => {
       renderAdminLayout();
 
       // should ensure the sidebar already render
-      await screen.findAllByText("adminSidebar.title");
+      await screen.findAllByText("Admin");
 
       const sidebars = screen.getAllByRole("complementary");
       const sidebar = sidebars[0];
@@ -96,9 +102,7 @@ describe("AdminLayout", () => {
       renderAdminLayout();
 
       await waitFor(() => {
-        expect(
-          screen.queryByText("adminSidebar.title"),
-        ).not.toBeInTheDocument();
+        expect(screen.queryByText("Admin")).not.toBeInTheDocument();
       });
     });
   });

--- a/src/pages/layouts/DefaultLayout.test.tsx
+++ b/src/pages/layouts/DefaultLayout.test.tsx
@@ -1,5 +1,5 @@
 vi.unmock("react-i18next");
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, vi, beforeEach, expect } from "vitest";
 import { MemoryRouter } from "react-router";
@@ -109,7 +109,10 @@ describe("DefaultLayout", () => {
 
       expect(navbar).toBeInTheDocument();
 
-      const navLinks = Array.from(navbar.querySelectorAll("a")).filter(
+      const desktopNav = navbar.querySelector(".md\\:flex");
+      if (!desktopNav) throw new Error("Desktop nav not found");
+
+      const navLinks = Array.from(desktopNav.querySelectorAll("a")).filter(
         (link) => {
           const href = link.getAttribute("href");
           return href && !href.startsWith("#");
@@ -124,7 +127,7 @@ describe("DefaultLayout", () => {
         expect(link.textContent).toBeTruthy();
       });
 
-      expect(screen.queryByText("Admin")).not.toBeInTheDocument();
+      expect(within(desktopNav).queryByText("Admin")).not.toBeInTheDocument();
     });
 
     it("should render the Navbar with all links for an admin user", async () => {
@@ -136,7 +139,10 @@ describe("DefaultLayout", () => {
 
       const navbars = await screen.findAllByRole("navigation");
       const navbar = navbars[0];
-      const navLinks = Array.from(navbar.querySelectorAll("a")).filter(
+      const desktopNav = navbar.querySelector(".md\\:flex");
+      if (!desktopNav) throw new Error("Desktop nav not found");
+
+      const navLinks = Array.from(desktopNav.querySelectorAll("a")).filter(
         (link) => {
           const href = link.getAttribute("href");
           return href && !href.startsWith("#");
@@ -151,7 +157,7 @@ describe("DefaultLayout", () => {
         expect(link.textContent).toBeTruthy();
       });
 
-      expect(screen.getByText("Admin")).toBeInTheDocument();
+      expect(within(desktopNav).getByText("Admin")).toBeInTheDocument();
     });
   });
 
@@ -166,7 +172,10 @@ describe("DefaultLayout", () => {
 
       const navbars = await screen.findAllByRole("navigation");
       const navbar = navbars[0];
-      const navLinks = Array.from(navbar.querySelectorAll("a")).filter(
+      const desktopNav = navbar.querySelector(".md\\:flex");
+      if (!desktopNav) throw new Error("Desktop nav not found");
+
+      const navLinks = Array.from(desktopNav.querySelectorAll("a")).filter(
         (link) => {
           const href = link.getAttribute("href");
           return href && href !== "/" && !href.startsWith("#");
@@ -192,7 +201,11 @@ describe("DefaultLayout", () => {
 
       const navbars = await screen.findAllByRole("navigation");
       const navbar = navbars[0];
-      const navLinks = Array.from(navbar.querySelectorAll("a")).filter(
+
+      const desktopNav = navbar.querySelector(".md\\:flex");
+      if (!desktopNav) throw new Error("Desktop nav not found");
+
+      const navLinks = Array.from(desktopNav.querySelectorAll("a")).filter(
         (link) => {
           const href = link.getAttribute("href");
           return href && href !== "/" && !href.startsWith("#");
@@ -208,7 +221,7 @@ describe("DefaultLayout", () => {
       }
 
       // Verify Admin link is not there to be navigated to
-      expect(screen.queryByText("Admin")).not.toBeInTheDocument();
+      expect(within(desktopNav).queryByText("Admin")).not.toBeInTheDocument();
     });
   });
 });

--- a/src/pages/layouts/DefaultLayout.test.tsx
+++ b/src/pages/layouts/DefaultLayout.test.tsx
@@ -132,6 +132,22 @@ describe("DefaultLayout", () => {
       });
 
       expect(within(desktopNav).queryByText("Admin")).not.toBeInTheDocument();
+
+      const mobileNavLinks = Array.from(mobileNav.querySelectorAll("a")).filter(
+        (link) => {
+          const href = link.getAttribute("href");
+          return href && !href.startsWith("#");
+        },
+      );
+
+      expect(mobileNavLinks.length).toBe(3);
+
+      mobileNavLinks.forEach((link) => {
+        expect(link.getAttribute("href")).toBeTruthy();
+        expect(link.textContent).toBeTruthy();
+      });
+
+      expect(within(mobileNav).queryByText("Admin")).not.toBeInTheDocument();
     });
 
     it("should render the Navbar with all links for an admin user", async () => {
@@ -166,6 +182,22 @@ describe("DefaultLayout", () => {
       });
 
       expect(within(desktopNav).getByText("Admin")).toBeInTheDocument();
+
+      const mobileNavLinks = Array.from(mobileNav.querySelectorAll("a")).filter(
+        (link) => {
+          const href = link.getAttribute("href");
+          return href && !href.startsWith("#");
+        },
+      );
+
+      expect(mobileNavLinks.length).toBe(4);
+
+      mobileNavLinks.forEach((link) => {
+        expect(link.getAttribute("href")).toBeTruthy();
+        expect(link.textContent).toBeTruthy();
+      });
+
+      expect(within(mobileNav).getByText("Admin")).toBeInTheDocument();
     });
   });
 
@@ -187,12 +219,12 @@ describe("DefaultLayout", () => {
       const desktopNav = navbar.querySelector(".md\\:flex") as HTMLElement;
       expect(desktopNav).toBeInTheDocument();
 
-      const navLinks = Array.from(desktopNav.querySelectorAll("a")).filter(
-        (link) => {
-          const href = link.getAttribute("href");
-          return href && href !== "/" && !href.startsWith("#");
-        },
-      );
+      const navLinks = Array.from(
+        navbar.querySelectorAll(".md\\:flex a, .md\\:hidden a"),
+      ).filter((link) => {
+        const href = link.getAttribute("href");
+        return href && href !== "/" && !href.startsWith("#");
+      });
 
       for (const link of navLinks) {
         await user.click(link);
@@ -220,12 +252,12 @@ describe("DefaultLayout", () => {
       const desktopNav = navbar.querySelector(".md\\:flex") as HTMLElement;
       expect(desktopNav).toBeInTheDocument();
 
-      const navLinks = Array.from(desktopNav.querySelectorAll("a")).filter(
-        (link) => {
-          const href = link.getAttribute("href");
-          return href && href !== "/" && !href.startsWith("#");
-        },
-      );
+      const navLinks = Array.from(
+        navbar.querySelectorAll(".md\\:flex a, .md\\:hidden a"),
+      ).filter((link) => {
+        const href = link.getAttribute("href");
+        return href && href !== "/" && !href.startsWith("#");
+      });
 
       for (const link of navLinks) {
         await user.click(link);
@@ -237,6 +269,7 @@ describe("DefaultLayout", () => {
 
       // Verify Admin link is not there to be navigated to
       expect(within(desktopNav).queryByText("Admin")).not.toBeInTheDocument();
+      expect(within(mobileNav).queryByText("Admin")).not.toBeInTheDocument();
     });
   });
 });

--- a/src/pages/layouts/DefaultLayout.test.tsx
+++ b/src/pages/layouts/DefaultLayout.test.tsx
@@ -1,3 +1,4 @@
+vi.unmock("react-i18next");
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, vi, beforeEach, expect } from "vitest";
@@ -10,6 +11,8 @@ import { AuthProvider } from "@/components/auth/AuthProvider";
 import DefaultLayout from "./DefaultLayout";
 import App from "@/App";
 import type * as ReactCookie from "react-cookie";
+import i18n from "@/i18n";
+import { I18nextProvider } from "react-i18next";
 
 vi.mock("react-cookie", async () => {
   const mod = await vi.importActual<typeof ReactCookie>("react-cookie");
@@ -33,8 +36,9 @@ vi.mock("@/lib/request/getGroups", () => ({
 }));
 
 describe("DefaultLayout", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
+    await i18n.changeLanguage("en");
   });
 
   function renderDefaultLayout(initialRoute = "/") {
@@ -50,16 +54,45 @@ describe("DefaultLayout", () => {
     vi.mocked(getAccessToken).mockReturnValue("mock-token");
 
     return render(
-      <QueryClientProvider client={queryClient}>
-        <CookiesProvider>
-          <MemoryRouter initialEntries={[initialRoute]}>
-            <AuthProvider>
-              <DefaultLayout />
-              <App />
-            </AuthProvider>
-          </MemoryRouter>
-        </CookiesProvider>
-      </QueryClientProvider>,
+      <I18nextProvider i18n={i18n}>
+        <QueryClientProvider client={queryClient}>
+          <CookiesProvider>
+            <MemoryRouter initialEntries={[initialRoute]}>
+              <AuthProvider>
+                <DefaultLayout />
+                <App />
+              </AuthProvider>
+            </MemoryRouter>
+          </CookiesProvider>
+        </QueryClientProvider>
+      </I18nextProvider>,
+    );
+  }
+
+  function renderDefaultLayoutOnly(initialRoute = "/") {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    vi.mocked(useCookies).mockReturnValue([
+      { refreshToken: "mock-refresh" },
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+    ]);
+    vi.mocked(getAccessToken).mockReturnValue("mock-token");
+
+    return render(
+      <I18nextProvider i18n={i18n}>
+        <QueryClientProvider client={queryClient}>
+          <CookiesProvider>
+            <MemoryRouter initialEntries={[initialRoute]}>
+              <AuthProvider>
+                <DefaultLayout />
+              </AuthProvider>
+            </MemoryRouter>
+          </CookiesProvider>
+        </QueryClientProvider>
+      </I18nextProvider>,
     );
   }
 
@@ -69,7 +102,7 @@ describe("DefaultLayout", () => {
         Role: "user",
         Email: "user@example.com",
       });
-      renderDefaultLayout();
+      renderDefaultLayoutOnly();
 
       const navbars = await screen.findAllByRole("navigation");
       const navbar = navbars[0];
@@ -91,7 +124,7 @@ describe("DefaultLayout", () => {
         expect(link.textContent).toBeTruthy();
       });
 
-      expect(screen.queryByText(/navbar\.adminLink/i)).not.toBeInTheDocument();
+      expect(screen.queryByText("Admin")).not.toBeInTheDocument();
     });
 
     it("should render the Navbar with all links for an admin user", async () => {
@@ -99,7 +132,7 @@ describe("DefaultLayout", () => {
         Role: "admin",
         Email: "admin@example.com",
       });
-      renderDefaultLayout();
+      renderDefaultLayoutOnly();
 
       const navbars = await screen.findAllByRole("navigation");
       const navbar = navbars[0];
@@ -118,7 +151,7 @@ describe("DefaultLayout", () => {
         expect(link.textContent).toBeTruthy();
       });
 
-      expect(screen.getByText(/navbar\.adminLink/i)).toBeInTheDocument();
+      expect(screen.getByText("Admin")).toBeInTheDocument();
     });
   });
 
@@ -175,7 +208,7 @@ describe("DefaultLayout", () => {
       }
 
       // Verify Admin link is not there to be navigated to
-      expect(screen.queryByText(/navbar\.adminLink/i)).not.toBeInTheDocument();
+      expect(screen.queryByText("Admin")).not.toBeInTheDocument();
     });
   });
 });

--- a/src/pages/layouts/DefaultLayout.test.tsx
+++ b/src/pages/layouts/DefaultLayout.test.tsx
@@ -116,17 +116,17 @@ describe("DefaultLayout", () => {
       expect(desktopNav).toBeInTheDocument();
 
       // Because we have two navbar rendering path, one for mobile and one for desktop. We should select the desktop navbar css here.
-      const navLinks = Array.from(desktopNav.querySelectorAll("a")).filter(
-        (link) => {
-          const href = link.getAttribute("href");
-          return href && !href.startsWith("#");
-        },
-      );
+      const desktopNavLinks = Array.from(
+        desktopNav.querySelectorAll("a"),
+      ).filter((link) => {
+        const href = link.getAttribute("href");
+        return href && !href.startsWith("#");
+      });
 
       // Standard user: Logo (to /groups), Groups, Settings
-      expect(navLinks.length).toBe(3);
+      expect(desktopNavLinks.length).toBe(3);
 
-      navLinks.forEach((link) => {
+      desktopNavLinks.forEach((link) => {
         expect(link.getAttribute("href")).toBeTruthy();
         expect(link.textContent).toBeTruthy();
       });
@@ -166,17 +166,17 @@ describe("DefaultLayout", () => {
       const desktopNav = navbar.querySelector(".md\\:flex") as HTMLElement;
       expect(desktopNav).toBeInTheDocument();
 
-      const navLinks = Array.from(desktopNav.querySelectorAll("a")).filter(
-        (link) => {
-          const href = link.getAttribute("href");
-          return href && !href.startsWith("#");
-        },
-      );
+      const desktopNavLinks = Array.from(
+        desktopNav.querySelectorAll("a"),
+      ).filter((link) => {
+        const href = link.getAttribute("href");
+        return href && !href.startsWith("#");
+      });
 
       // Admin user: Logo (to /groups), Groups, Settings, Admin
-      expect(navLinks.length).toBe(4);
+      expect(desktopNavLinks.length).toBe(4);
 
-      navLinks.forEach((link) => {
+      desktopNavLinks.forEach((link) => {
         expect(link.getAttribute("href")).toBeTruthy();
         expect(link.textContent).toBeTruthy();
       });
@@ -219,14 +219,29 @@ describe("DefaultLayout", () => {
       const desktopNav = navbar.querySelector(".md\\:flex") as HTMLElement;
       expect(desktopNav).toBeInTheDocument();
 
-      const navLinks = Array.from(
-        navbar.querySelectorAll(".md\\:flex a, .md\\:hidden a"),
+      const desktopNavLinks = Array.from(
+        desktopNav.querySelectorAll("a"),
       ).filter((link) => {
         const href = link.getAttribute("href");
         return href && href !== "/" && !href.startsWith("#");
       });
 
-      for (const link of navLinks) {
+      for (const link of desktopNavLinks) {
+        await user.click(link);
+        await waitFor(() => {
+          const notFoundText = screen.queryByText(/404 Not Found/i);
+          expect(notFoundText).not.toBeInTheDocument();
+        });
+      }
+
+      const mobileNavLinks = Array.from(mobileNav.querySelectorAll("a")).filter(
+        (link) => {
+          const href = link.getAttribute("href");
+          return href && href !== "/" && !href.startsWith("#");
+        },
+      );
+
+      for (const link of mobileNavLinks) {
         await user.click(link);
         await waitFor(() => {
           const notFoundText = screen.queryByText(/404 Not Found/i);
@@ -252,14 +267,14 @@ describe("DefaultLayout", () => {
       const desktopNav = navbar.querySelector(".md\\:flex") as HTMLElement;
       expect(desktopNav).toBeInTheDocument();
 
-      const navLinks = Array.from(
-        navbar.querySelectorAll(".md\\:flex a, .md\\:hidden a"),
+      const desktopNavLinks = Array.from(
+        desktopNav.querySelectorAll("a"),
       ).filter((link) => {
         const href = link.getAttribute("href");
         return href && href !== "/" && !href.startsWith("#");
       });
 
-      for (const link of navLinks) {
+      for (const link of desktopNavLinks) {
         await user.click(link);
         await waitFor(() => {
           const notFoundText = screen.queryByText(/404 Not Found/i);
@@ -269,6 +284,23 @@ describe("DefaultLayout", () => {
 
       // Verify Admin link is not there to be navigated to
       expect(within(desktopNav).queryByText("Admin")).not.toBeInTheDocument();
+
+      const mobileNavLinks = Array.from(mobileNav.querySelectorAll("a")).filter(
+        (link) => {
+          const href = link.getAttribute("href");
+          return href && href !== "/" && !href.startsWith("#");
+        },
+      );
+
+      for (const link of mobileNavLinks) {
+        await user.click(link);
+        await waitFor(() => {
+          const notFoundText = screen.queryByText(/404 Not Found/i);
+          expect(notFoundText).not.toBeInTheDocument();
+        });
+      }
+
+      // Verify Admin link is not there to be navigated to
       expect(within(mobileNav).queryByText("Admin")).not.toBeInTheDocument();
     });
   });

--- a/src/pages/layouts/DefaultLayout.test.tsx
+++ b/src/pages/layouts/DefaultLayout.test.tsx
@@ -109,9 +109,13 @@ describe("DefaultLayout", () => {
 
       expect(navbar).toBeInTheDocument();
 
-      const desktopNav = navbar.querySelector(".md\\:flex") as HTMLElement;
-      if (!desktopNav) throw new Error("Desktop nav not found");
+      const mobileNav = navbar.querySelector(".md\\:hidden") as HTMLElement;
+      expect(mobileNav).toBeInTheDocument();
 
+      const desktopNav = navbar.querySelector(".md\\:flex") as HTMLElement;
+      expect(desktopNav).toBeInTheDocument();
+
+      // Because we have two navbar rendering path, one for mobile and one for desktop. We should select the desktop navbar css here.
       const navLinks = Array.from(desktopNav.querySelectorAll("a")).filter(
         (link) => {
           const href = link.getAttribute("href");
@@ -139,9 +143,12 @@ describe("DefaultLayout", () => {
 
       const navbars = await screen.findAllByRole("navigation");
       const navbar = navbars[0];
-      // Because we have two navbar rendering path, one for mobile and one for desktop. We should select the desktop navbar css here.
+
+      const mobileNav = navbar.querySelector(".md\\:hidden") as HTMLElement;
+      expect(mobileNav).toBeInTheDocument();
+
       const desktopNav = navbar.querySelector(".md\\:flex") as HTMLElement;
-      if (!desktopNav) throw new Error("Desktop nav not found");
+      expect(desktopNav).toBeInTheDocument();
 
       const navLinks = Array.from(desktopNav.querySelectorAll("a")).filter(
         (link) => {
@@ -173,8 +180,12 @@ describe("DefaultLayout", () => {
 
       const navbars = await screen.findAllByRole("navigation");
       const navbar = navbars[0];
+
+      const mobileNav = navbar.querySelector(".md\\:hidden") as HTMLElement;
+      expect(mobileNav).toBeInTheDocument();
+
       const desktopNav = navbar.querySelector(".md\\:flex") as HTMLElement;
-      if (!desktopNav) throw new Error("Desktop nav not found");
+      expect(desktopNav).toBeInTheDocument();
 
       const navLinks = Array.from(desktopNav.querySelectorAll("a")).filter(
         (link) => {
@@ -203,8 +214,11 @@ describe("DefaultLayout", () => {
       const navbars = await screen.findAllByRole("navigation");
       const navbar = navbars[0];
 
+      const mobileNav = navbar.querySelector(".md\\:hidden") as HTMLElement;
+      expect(mobileNav).toBeInTheDocument();
+
       const desktopNav = navbar.querySelector(".md\\:flex") as HTMLElement;
-      if (!desktopNav) throw new Error("Desktop nav not found");
+      expect(desktopNav).toBeInTheDocument();
 
       const navLinks = Array.from(desktopNav.querySelectorAll("a")).filter(
         (link) => {

--- a/src/pages/layouts/DefaultLayout.test.tsx
+++ b/src/pages/layouts/DefaultLayout.test.tsx
@@ -139,6 +139,7 @@ describe("DefaultLayout", () => {
 
       const navbars = await screen.findAllByRole("navigation");
       const navbar = navbars[0];
+      // Because we have two navbar rendering path, one for mobile and one for desktop. We should select the desktop navbar css here.
       const desktopNav = navbar.querySelector(".md\\:flex") as HTMLElement;
       if (!desktopNav) throw new Error("Desktop nav not found");
 

--- a/src/pages/layouts/DefaultLayout.test.tsx
+++ b/src/pages/layouts/DefaultLayout.test.tsx
@@ -109,7 +109,7 @@ describe("DefaultLayout", () => {
 
       expect(navbar).toBeInTheDocument();
 
-      const desktopNav = navbar.querySelector(".md\\:flex");
+      const desktopNav = navbar.querySelector(".md\\:flex") as HTMLElement;
       if (!desktopNav) throw new Error("Desktop nav not found");
 
       const navLinks = Array.from(desktopNav.querySelectorAll("a")).filter(
@@ -139,7 +139,7 @@ describe("DefaultLayout", () => {
 
       const navbars = await screen.findAllByRole("navigation");
       const navbar = navbars[0];
-      const desktopNav = navbar.querySelector(".md\\:flex");
+      const desktopNav = navbar.querySelector(".md\\:flex") as HTMLElement;
       if (!desktopNav) throw new Error("Desktop nav not found");
 
       const navLinks = Array.from(desktopNav.querySelectorAll("a")).filter(
@@ -172,7 +172,7 @@ describe("DefaultLayout", () => {
 
       const navbars = await screen.findAllByRole("navigation");
       const navbar = navbars[0];
-      const desktopNav = navbar.querySelector(".md\\:flex");
+      const desktopNav = navbar.querySelector(".md\\:flex") as HTMLElement;
       if (!desktopNav) throw new Error("Desktop nav not found");
 
       const navLinks = Array.from(desktopNav.querySelectorAll("a")).filter(
@@ -202,7 +202,7 @@ describe("DefaultLayout", () => {
       const navbars = await screen.findAllByRole("navigation");
       const navbar = navbars[0];
 
-      const desktopNav = navbar.querySelector(".md\\:flex");
+      const desktopNav = navbar.querySelector(".md\\:flex") as HTMLElement;
       if (!desktopNav) throw new Error("Desktop nav not found");
 
       const navLinks = Array.from(desktopNav.querySelectorAll("a")).filter(

--- a/src/pages/layouts/GroupLayout.test.tsx
+++ b/src/pages/layouts/GroupLayout.test.tsx
@@ -1,3 +1,4 @@
+vi.unmock("react-i18next");
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, vi, beforeEach, expect, Mock } from "vitest";
@@ -12,6 +13,8 @@ import GroupLayout from "./GroupLayout";
 import App from "@/App";
 import type * as ReactCookie from "react-cookie";
 import { AccessLevelOwner } from "@/types/group";
+import i18n from "@/i18n";
+import { I18nextProvider } from "react-i18next";
 
 vi.mock("react-cookie", async () => {
   const mod = await vi.importActual<typeof ReactCookie>("react-cookie");
@@ -58,8 +61,9 @@ describe("GroupLayout", () => {
     },
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
+    await i18n.changeLanguage("en");
     (useGetGroupById as Mock).mockReturnValue({
       data: mockGroup,
       isLoading: false,
@@ -81,23 +85,25 @@ describe("GroupLayout", () => {
     vi.mocked(jwtDecode).mockReturnValue({ Role: "user" });
 
     return render(
-      <QueryClientProvider client={queryClient}>
-        <CookiesProvider>
-          <MemoryRouter initialEntries={[initialRoute]}>
-            <AuthProvider>
-              <GroupLayout />
-              <App />
-            </AuthProvider>
-          </MemoryRouter>
-        </CookiesProvider>
-      </QueryClientProvider>,
+      <I18nextProvider i18n={i18n}>
+        <QueryClientProvider client={queryClient}>
+          <CookiesProvider>
+            <MemoryRouter initialEntries={[initialRoute]}>
+              <AuthProvider>
+                <GroupLayout />
+                <App />
+              </AuthProvider>
+            </MemoryRouter>
+          </CookiesProvider>
+        </QueryClientProvider>
+      </I18nextProvider>,
     );
   }
 
   describe("Data Loading & Error States", () => {
     it("should render the group title and all navigation links in the sidebar when data is loaded", async () => {
       renderGroupLayout();
-      await screen.findByText(mockGroup.title);
+      await screen.findByText(/Engine.*luster/);
 
       const sidebars = screen.getAllByRole("complementary");
       const sidebar = sidebars[0];
@@ -128,7 +134,7 @@ describe("GroupLayout", () => {
       // In App.tsx, /groups renders GroupListPage
       // We check if the sidebar with group title is NOT present and we don't see 404.
       await waitFor(() => {
-        expect(screen.queryByText(mockGroup.title)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Engine.*luster/)).not.toBeInTheDocument();
         expect(screen.queryByText(/404 Not Found/i)).not.toBeInTheDocument();
       });
     });
@@ -139,7 +145,7 @@ describe("GroupLayout", () => {
       const user = userEvent.setup();
       renderGroupLayout();
 
-      await screen.findByText(mockGroup.title);
+      await screen.findByText(/Engine.*luster/);
 
       const sidebars = await screen.findAllByRole("complementary");
       const sidebar = sidebars[0];

--- a/src/pages/layouts/GroupLayout.test.tsx
+++ b/src/pages/layouts/GroupLayout.test.tsx
@@ -15,6 +15,7 @@ import type * as ReactCookie from "react-cookie";
 import { AccessLevelOwner } from "@/types/group";
 import i18n from "@/i18n";
 import { I18nextProvider } from "react-i18next";
+import { truncateMiddle } from "@/components/Sidebar";
 
 vi.mock("react-cookie", async () => {
   const mod = await vi.importActual<typeof ReactCookie>("react-cookie");
@@ -103,7 +104,7 @@ describe("GroupLayout", () => {
   describe("Data Loading & Error States", () => {
     it("should render the group title and all navigation links in the sidebar when data is loaded", async () => {
       renderGroupLayout();
-      await screen.findByText(/Engine.*luster/);
+      await screen.findByText(truncateMiddle(mockGroup.title));
 
       const sidebars = screen.getAllByRole("complementary");
       const sidebar = sidebars[0];
@@ -134,7 +135,9 @@ describe("GroupLayout", () => {
       // In App.tsx, /groups renders GroupListPage
       // We check if the sidebar with group title is NOT present and we don't see 404.
       await waitFor(() => {
-        expect(screen.queryByText(/Engine.*luster/)).not.toBeInTheDocument();
+        expect(
+          screen.queryByText(truncateMiddle(mockGroup.title)),
+        ).not.toBeInTheDocument();
         expect(screen.queryByText(/404 Not Found/i)).not.toBeInTheDocument();
       });
     });
@@ -145,7 +148,7 @@ describe("GroupLayout", () => {
       const user = userEvent.setup();
       renderGroupLayout();
 
-      await screen.findByText(/Engine.*luster/);
+      await screen.findByText(truncateMiddle(mockGroup.title));
 
       const sidebars = await screen.findAllByRole("complementary");
       const sidebar = sidebars[0];

--- a/src/pages/layouts/JobLayout.test.tsx
+++ b/src/pages/layouts/JobLayout.test.tsx
@@ -1,3 +1,4 @@
+vi.unmock("react-i18next");
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, vi, beforeEach, expect } from "vitest";
@@ -10,6 +11,8 @@ import { AuthProvider } from "@/components/auth/AuthProvider";
 import JobLayout from "./JobLayout";
 import App from "@/App";
 import type * as ReactCookie from "react-cookie";
+import i18n from "@/i18n";
+import { I18nextProvider } from "react-i18next";
 
 vi.mock("react-cookie", async () => {
   const mod = await vi.importActual<typeof ReactCookie>("react-cookie");
@@ -28,8 +31,9 @@ vi.mock("@/lib/request/refreshAuthToken", () => ({
 }));
 
 describe("JobLayout", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
+    await i18n.changeLanguage("en");
   });
 
   function renderJobLayout(initialRoute = "/jobs") {
@@ -49,16 +53,18 @@ describe("JobLayout", () => {
     });
 
     return render(
-      <QueryClientProvider client={queryClient}>
-        <CookiesProvider>
-          <MemoryRouter initialEntries={[initialRoute]}>
-            <AuthProvider>
-              <JobLayout />
-              <App />
-            </AuthProvider>
-          </MemoryRouter>
-        </CookiesProvider>
-      </QueryClientProvider>,
+      <I18nextProvider i18n={i18n}>
+        <QueryClientProvider client={queryClient}>
+          <CookiesProvider>
+            <MemoryRouter initialEntries={[initialRoute]}>
+              <AuthProvider>
+                <JobLayout />
+                <App />
+              </AuthProvider>
+            </MemoryRouter>
+          </CookiesProvider>
+        </QueryClientProvider>
+      </I18nextProvider>,
     );
   }
 
@@ -69,7 +75,7 @@ describe("JobLayout", () => {
       renderJobLayout();
 
       // ensure the side bar has already rendered.
-      await screen.findAllByText("jobsSideBar.title");
+      await screen.findAllByText("Jobs");
 
       const sidebars = screen.getAllByRole("complementary");
       const sidebar = sidebars[0];

--- a/src/pages/layouts/SettingLayout.test.tsx
+++ b/src/pages/layouts/SettingLayout.test.tsx
@@ -1,3 +1,4 @@
+vi.unmock("react-i18next");
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, vi, beforeEach, expect } from "vitest";
@@ -10,6 +11,8 @@ import { AuthProvider } from "@/components/auth/AuthProvider";
 import SettingLayout from "./SettingLayout";
 import App from "@/App";
 import type * as ReactCookie from "react-cookie";
+import i18n from "@/i18n";
+import { I18nextProvider } from "react-i18next";
 
 vi.mock("react-cookie", async () => {
   const mod = await vi.importActual<typeof ReactCookie>("react-cookie");
@@ -33,8 +36,9 @@ vi.mock("@/lib/request/getKeys", () => ({
 }));
 
 describe("SettingLayout", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
+    await i18n.changeLanguage("en");
   });
 
   function renderSettingLayout(initialRoute = "/setting/general") {
@@ -51,16 +55,18 @@ describe("SettingLayout", () => {
     vi.mocked(jwtDecode).mockReturnValue({ Role: "user" });
 
     return render(
-      <QueryClientProvider client={queryClient}>
-        <CookiesProvider>
-          <MemoryRouter initialEntries={[initialRoute]}>
-            <AuthProvider>
-              <SettingLayout />
-              <App />
-            </AuthProvider>
-          </MemoryRouter>
-        </CookiesProvider>
-      </QueryClientProvider>,
+      <I18nextProvider i18n={i18n}>
+        <QueryClientProvider client={queryClient}>
+          <CookiesProvider>
+            <MemoryRouter initialEntries={[initialRoute]}>
+              <AuthProvider>
+                <SettingLayout />
+                <App />
+              </AuthProvider>
+            </MemoryRouter>
+          </CookiesProvider>
+        </QueryClientProvider>
+      </I18nextProvider>,
     );
   }
 
@@ -70,7 +76,7 @@ describe("SettingLayout", () => {
       renderSettingLayout();
 
       // Ensure layout is ready
-      await screen.findAllByText("settingSideBar.title");
+      await screen.findAllByText("Settings");
 
       const sidebars = screen.getAllByRole("complementary");
       const sidebar = sidebars[0];

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -2,6 +2,7 @@
 import "@testing-library/jest-dom";
 import { vi } from "vitest";
 
+//mock localStorage in setup.ts because i18n calls getItem at import time in jsdom
 const localStorageMock = {
   getItem: vi.fn().mockReturnValue(null),
   setItem: vi.fn(),

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -2,6 +2,14 @@
 import "@testing-library/jest-dom";
 import { vi } from "vitest";
 
+const localStorageMock = {
+  getItem: vi.fn().mockReturnValue(null),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+};
+Object.defineProperty(window, "localStorage", { value: localStorageMock });
+
 // 全域 mock i18n：保留其他 export（如 initReactI18next），只覆蓋 useTranslation/Trans
 vi.mock("react-i18next", async () => {
   const actual =


### PR DESCRIPTION
## Type of changes

- Fix

## Purpose

- Fix sidebar text truncation and selection failures in RWD layouts
- Mock localStorage in setupTests.ts to handle i18n initialization
- Select dekstop navbar to skip dubplicate mobile link 
