### PR TITLE
[CLUST296] Send LDAP group name to backend when creating group

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -247,6 +247,7 @@
       "courseTitlePlaceholder": "Give your new group a title",
       "ldapGroupNameTitle": "LDAP Group Name",
       "ldapGroupNamePlaceholder": "The group name in LDAP",
+      "ldapGroupNameFormatError": "LDAP group name must start with a letter and end with a letter or number. It can only contain letters, numbers, hyphens, and spaces.",
       "descriptionTitle": "Description",
       "courseDescriptionPlaceholder": "Say something about this group",
       "linkTitle": "Link Resources",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -245,6 +245,8 @@
     "createGroup": {
       "courseTitle": "Group Title",
       "courseTitlePlaceholder": "Give your new group a title",
+      "ldapGroupNameTitle": "LDAP Group Name",
+      "ldapGroupNamePlaceholder": "The group name in LDAP",
       "descriptionTitle": "Description",
       "courseDescriptionPlaceholder": "Say something about this group",
       "linkTitle": "Link Resources",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -245,6 +245,8 @@
     "createGroup": {
       "courseTitle": "群組名稱",
       "courseTitlePlaceholder": "為你的新群組取個名稱",
+      "ldapGroupNameTitle": "LDAP 群組名稱",
+      "ldapGroupNamePlaceholder": "LDAP 中的群組名稱",
       "descriptionTitle": "描述",
       "courseDescriptionPlaceholder": "介紹一下這個群組",
       "linkTitle": "連結資源",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -247,6 +247,7 @@
       "courseTitlePlaceholder": "為你的新群組取個名稱",
       "ldapGroupNameTitle": "LDAP 群組名稱",
       "ldapGroupNamePlaceholder": "LDAP 中的群組名稱",
+      "ldapGroupNameFormatError": "LDAP 群組名稱必須以字母開頭，以字母或數字結尾，且僅能包含字母、數字、連字號(-)與空格。",
       "descriptionTitle": "描述",
       "courseDescriptionPlaceholder": "介紹一下這個群組",
       "linkTitle": "連結資源",

--- a/src/pages/group/CreateGroup.test.tsx
+++ b/src/pages/group/CreateGroup.test.tsx
@@ -192,11 +192,15 @@ describe("CreateGroup", () => {
       const titleInput = screen.getByPlaceholderText(
         "groupPages.createGroup.courseTitlePlaceholder",
       );
+      const ldapInput = screen.getByPlaceholderText(
+        "groupPages.createGroup.ldapGroupNamePlaceholder",
+      );
       const descriptionInput = screen.getByPlaceholderText(
         "groupPages.createGroup.courseDescriptionPlaceholder",
       );
 
       await user.type(titleInput, "Test Group");
+      await user.type(ldapInput, "test-ldap-group");
       await user.type(descriptionInput, "Test Description");
 
       expect(titleInput).toHaveValue("Test Group");
@@ -242,11 +246,15 @@ describe("CreateGroup", () => {
       const titleInput = screen.getByPlaceholderText(
         "groupPages.createGroup.courseTitlePlaceholder",
       );
+      const ldapInput = screen.getByPlaceholderText(
+        "groupPages.createGroup.ldapGroupNamePlaceholder",
+      );
       const descriptionInput = screen.getByPlaceholderText(
         "groupPages.createGroup.courseDescriptionPlaceholder",
       );
 
       await user.type(titleInput, "Test Group");
+      await user.type(ldapInput, "test-ldap-group");
       await user.type(descriptionInput, "Test Description");
 
       const buttons = screen.getAllByRole("button");
@@ -379,6 +387,9 @@ describe("CreateGroup", () => {
       const titleInput = screen.getByPlaceholderText(
         "groupPages.createGroup.courseTitlePlaceholder",
       );
+      const ldapInput = screen.getByPlaceholderText(
+        "groupPages.createGroup.ldapGroupNamePlaceholder",
+      );
       const descriptionInput = screen.getByPlaceholderText(
         "groupPages.createGroup.courseDescriptionPlaceholder",
       );
@@ -393,6 +404,7 @@ describe("CreateGroup", () => {
       const linkUrlInput = urlInputs[urlInputs.length - 1];
 
       await user.type(titleInput, "Test Group");
+      await user.type(ldapInput, "test-ldap-group");
       await user.type(descriptionInput, "Test Description");
       await user.type(screen.getByTestId("member-id-0"), "student@example.com");
       await user.type(linkTitleInput, "Example");
@@ -429,6 +441,9 @@ describe("CreateGroup", () => {
       const titleInput = screen.getByPlaceholderText(
         "groupPages.createGroup.courseTitlePlaceholder",
       );
+      const ldapInput = screen.getByPlaceholderText(
+        "groupPages.createGroup.ldapGroupNamePlaceholder",
+      );
       const descriptionInput = screen.getByPlaceholderText(
         "groupPages.createGroup.courseDescriptionPlaceholder",
       );
@@ -443,6 +458,7 @@ describe("CreateGroup", () => {
       const linkUrlInput = urlInputs[urlInputs.length - 1];
 
       await user.type(titleInput, "Test Group");
+      await user.type(ldapInput, "test-ldap-group");
       await user.type(descriptionInput, "Test Description");
       await user.type(screen.getByTestId("member-id-0"), "student@example.com");
       await user.type(linkTitleInput, "Example");
@@ -472,6 +488,9 @@ describe("CreateGroup", () => {
       const titleInput = screen.getByPlaceholderText(
         "groupPages.createGroup.courseTitlePlaceholder",
       );
+      const ldapInput = screen.getByPlaceholderText(
+        "groupPages.createGroup.ldapGroupNamePlaceholder",
+      );
       const descriptionInput = screen.getByPlaceholderText(
         "groupPages.createGroup.courseDescriptionPlaceholder",
       );
@@ -486,6 +505,7 @@ describe("CreateGroup", () => {
       const linkUrlInput = urlInputs[urlInputs.length - 1];
 
       await user.type(titleInput, "Test Group");
+      await user.type(ldapInput, "test-ldap-group");
       await user.type(descriptionInput, "Test Description");
       await user.type(screen.getByTestId("member-id-0"), "student@example.com");
       await user.type(linkTitleInput, "Example");
@@ -563,11 +583,15 @@ describe("CreateGroup", () => {
       const titleInput = screen.getByPlaceholderText(
         "groupPages.createGroup.courseTitlePlaceholder",
       );
+      const ldapInput = screen.getByPlaceholderText(
+        "groupPages.createGroup.ldapGroupNamePlaceholder",
+      );
       const descriptionInput = screen.getByPlaceholderText(
         "groupPages.createGroup.courseDescriptionPlaceholder",
       );
 
       await user.type(titleInput, "Test Group");
+      await user.type(ldapInput, "test-ldap-group");
       await user.type(descriptionInput, "Test Description");
 
       // Add a second row
@@ -596,11 +620,15 @@ describe("CreateGroup", () => {
       const titleInput = screen.getByPlaceholderText(
         "groupPages.createGroup.courseTitlePlaceholder",
       );
+      const ldapInput = screen.getByPlaceholderText(
+        "groupPages.createGroup.ldapGroupNamePlaceholder",
+      );
       const descriptionInput = screen.getByPlaceholderText(
         "groupPages.createGroup.courseDescriptionPlaceholder",
       );
 
       await user.type(titleInput, "Test Group");
+      await user.type(ldapInput, "test-ldap-group");
       await user.type(descriptionInput, "Test Description");
 
       const memberIdInput = screen.getByTestId("member-id-0");
@@ -612,6 +640,7 @@ describe("CreateGroup", () => {
       await waitFor(() => {
         expect(mockCreateGroupMutate).toHaveBeenCalledWith({
           title: "Test Group",
+          ldapGroupName: "test-ldap-group",
           description: "Test Description",
           members: [
             {
@@ -631,11 +660,15 @@ describe("CreateGroup", () => {
       const titleInput = screen.getByPlaceholderText(
         "groupPages.createGroup.courseTitlePlaceholder",
       );
+      const ldapInput = screen.getByPlaceholderText(
+        "groupPages.createGroup.ldapGroupNamePlaceholder",
+      );
       const descriptionInput = screen.getByPlaceholderText(
         "groupPages.createGroup.courseDescriptionPlaceholder",
       );
 
       await user.type(titleInput, "Test Group");
+      await user.type(ldapInput, "test-ldap-group");
       await user.type(descriptionInput, "Test Description");
 
       // Add a second row but leave it empty
@@ -708,11 +741,15 @@ describe("CreateGroup", () => {
       const titleInput = screen.getByPlaceholderText(
         "groupPages.createGroup.courseTitlePlaceholder",
       );
+      const ldapInput = screen.getByPlaceholderText(
+        "groupPages.createGroup.ldapGroupNamePlaceholder",
+      );
       const descriptionInput = screen.getByPlaceholderText(
         "groupPages.createGroup.courseDescriptionPlaceholder",
       );
 
       await user.type(titleInput, "Test Group");
+      await user.type(ldapInput, "test-ldap-group");
       await user.type(descriptionInput, "Test Description");
 
       const memberIdInput = screen.getByTestId("member-id-0");

--- a/src/pages/group/CreateGroup.tsx
+++ b/src/pages/group/CreateGroup.tsx
@@ -36,6 +36,7 @@ export default function AddGroupPage() {
   const { roleNameToId, getRolesByAccessLevel } = useRoleMapper();
 
   const [title, setTitle] = useState("");
+  const [ldapGroupName, setLdapGroupName] = useState("");
   const [description, setDescription] = useState("");
   const [links, setLinks] = useState<GroupLinkPayload[]>([]);
   const [newLink, setNewLink] = useState<GroupLinkPayload>({
@@ -110,7 +111,19 @@ export default function AddGroupPage() {
     return `https://${trimmed}`;
   }
 
+  function isLdapGroupNameVerify(ldapGroupName: string): boolean {
+    if (/^[a-zA-Z]([a-zA-Z0-9- ]*[a-zA-Z0-9])?$/.test(ldapGroupName)) {
+      return true;
+    }
+    return false;
+  }
+
+  const isLdapValid = !ldapGroupName || isLdapGroupNameVerify(ldapGroupName);
+
   const handleSave = () => {
+    if (!isLdapValid) {
+      return;
+    }
     const newMembers = members.map((m) => {
       const roleId = roleNameToId(m.roleName);
       if (!roleId) throw new Error(`Invalid role: ${m.roleName}`);
@@ -131,6 +144,7 @@ export default function AddGroupPage() {
 
     createGroup.mutate({
       title,
+      ldapGroupName,
       description,
       members: newMembers,
       links: linksToSubmit,
@@ -175,6 +189,21 @@ export default function AddGroupPage() {
               placeholder={t("groupPages.createGroup.courseTitlePlaceholder")}
               value={title}
               onChange={(e) => setTitle(e.target.value)}
+            />
+          </CardContent>
+
+          {/* LDAP Group Name */}
+          <CardHeader className="mt-6">
+            <CardTitle className="text-2xl">
+              {t("groupPages.createGroup.ldapGroupNameTitle")}*
+            </CardTitle>
+          </CardHeader>
+
+          <CardContent>
+            <Textarea
+              placeholder={t("groupPages.createGroup.ldapGroupNamePlaceholder")}
+              value={ldapGroupName}
+              onChange={(e) => setLdapGroupName(e.target.value)}
             />
           </CardContent>
 

--- a/src/pages/group/CreateGroup.tsx
+++ b/src/pages/group/CreateGroup.tsx
@@ -111,17 +111,17 @@ export default function AddGroupPage() {
     return `https://${trimmed}`;
   }
 
-  function isLdapGroupNameVerify(ldapGroupName: string): boolean {
+  function verifyLdapGroupName(ldapGroupName: string): boolean {
     if (/^[a-zA-Z]([a-zA-Z0-9- ]*[a-zA-Z0-9])?$/.test(ldapGroupName)) {
       return true;
     }
     return false;
   }
 
-  const isLdapValid = isLdapGroupNameVerify(ldapGroupName);
+  const isLdapGroupNameValid = verifyLdapGroupName(ldapGroupName);
 
   const handleSave = () => {
-    if (!isLdapValid) {
+    if (!isLdapGroupNameValid) {
       return;
     }
     const newMembers = members.map((m) => {
@@ -205,12 +205,12 @@ export default function AddGroupPage() {
               value={ldapGroupName}
               onChange={(e) => setLdapGroupName(e.target.value)}
               className={
-                !isLdapValid && ldapGroupName
+                !isLdapGroupNameValid && ldapGroupName
                   ? "border-destructive focus-visible:ring-destructive"
                   : ""
               }
             />
-            {!isLdapValid && ldapGroupName && (
+            {!isLdapGroupNameValid && ldapGroupName && (
               <p className="text-sm font-medium text-destructive mt-1">
                 {t("groupPages.createGroup.ldapGroupNameFormatError")}
               </p>
@@ -400,7 +400,7 @@ export default function AddGroupPage() {
             !title.trim() ||
             createGroup.isPending ||
             !description.trim() ||
-            !isLdapValid
+            !isLdapGroupNameValid
           }
         >
           {t("groupPages.createGroup.create")}

--- a/src/pages/group/CreateGroup.tsx
+++ b/src/pages/group/CreateGroup.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router";
 import { useTranslation } from "react-i18next";
-import { toast } from "sonner";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import AddMemberRow from "@/components/group/AddMemberRow";
@@ -123,7 +122,6 @@ export default function AddGroupPage() {
 
   const handleSave = () => {
     if (!isLdapValid) {
-      toast.error(t("groupPages.createGroup.ldapGroupNameFormatError"));
       return;
     }
     const newMembers = members.map((m) => {

--- a/src/pages/group/CreateGroup.tsx
+++ b/src/pages/group/CreateGroup.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useNavigate } from "react-router";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import AddMemberRow from "@/components/group/AddMemberRow";
@@ -118,10 +119,11 @@ export default function AddGroupPage() {
     return false;
   }
 
-  const isLdapValid = !ldapGroupName || isLdapGroupNameVerify(ldapGroupName);
+  const isLdapValid = isLdapGroupNameVerify(ldapGroupName);
 
   const handleSave = () => {
     if (!isLdapValid) {
+      toast.error(t("groupPages.createGroup.ldapGroupNameFormatError"));
       return;
     }
     const newMembers = members.map((m) => {
@@ -204,7 +206,17 @@ export default function AddGroupPage() {
               placeholder={t("groupPages.createGroup.ldapGroupNamePlaceholder")}
               value={ldapGroupName}
               onChange={(e) => setLdapGroupName(e.target.value)}
+              className={
+                !isLdapValid && ldapGroupName
+                  ? "border-destructive focus-visible:ring-destructive"
+                  : ""
+              }
             />
+            {!isLdapValid && ldapGroupName && (
+              <p className="text-sm font-medium text-destructive mt-1">
+                {t("groupPages.createGroup.ldapGroupNameFormatError")}
+              </p>
+            )}
           </CardContent>
 
           {/* Description */}

--- a/src/pages/group/CreateGroup.tsx
+++ b/src/pages/group/CreateGroup.tsx
@@ -200,7 +200,7 @@ export default function AddGroupPage() {
           </CardHeader>
 
           <CardContent>
-            <Textarea
+            <Input
               placeholder={t("groupPages.createGroup.ldapGroupNamePlaceholder")}
               value={ldapGroupName}
               onChange={(e) => setLdapGroupName(e.target.value)}
@@ -389,7 +389,8 @@ export default function AddGroupPage() {
             hasEmptyId ||
             !title.trim() ||
             createGroup.isPending ||
-            !description.trim()
+            !description.trim() ||
+            !isLdapValid
           }
         >
           {t("groupPages.createGroup.create")}

--- a/src/types/group.ts
+++ b/src/types/group.ts
@@ -57,6 +57,7 @@ export type GroupDetail = GroupSummary & {
 export type CreateGroupInput = {
   title: string;
   description: string;
+  ldapGroupName: string;
   members?: {
     member: string; // email or user id
     roleId: string;


### PR DESCRIPTION
## Type of changes

- Feat

## Purpose

- Add LDAP Group Name field in CreateGroup page
- LDAP group name must start with a letter and end with a letter or number. It can only contain letters, numbers, hyphens, and spaces.