### PR TITLE
[CLUST-312] Switch User Management and Role Access Config tab position in admin panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -89,7 +89,7 @@ const App = () => {
             </Route>
 
             <Route path="/admin" element={<AdminLayout />}>
-              <Route index element={<Navigate to="config" replace />} />
+              <Route index element={<Navigate to="users" replace />} />
               <Route path="config" element={<RoleConfiguration />} />
               <Route path="users" element={<UserConfiguration />} />
             </Route>

--- a/src/pages/layouts/AdminLayout.tsx
+++ b/src/pages/layouts/AdminLayout.tsx
@@ -27,12 +27,12 @@ export default function AdminLayout() {
 
   const adminNavItems: NavItem[] = [
     {
-      to: "/admin/config",
-      label: t("adminSidebar.roleAccessConfigLink"),
-    },
-    {
       to: "/admin/users",
       label: t("adminSidebar.userConfigLink"),
+    },
+    {
+      to: "/admin/config",
+      label: t("adminSidebar.roleAccessConfigLink"),
     },
   ];
 


### PR DESCRIPTION
## Type of changes

- Refactor

## Purpose

- Reorder the admin panel tabs by moving User Management before Role Access Config.
- Update the default landing page to match the new tab order. 