### PR TITLE
[CLUST-314] Block LDAP Group Name with Spaces

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -250,7 +250,7 @@
       "courseTitlePlaceholder": "Give your new group a title",
       "ldapGroupNameTitle": "LDAP Group Name",
       "ldapGroupNamePlaceholder": "The group name in LDAP",
-      "ldapGroupNameFormatError": "LDAP group name must start with a letter and end with a letter or number. It can only contain letters, numbers, hyphens, and spaces.",
+      "ldapGroupNameFormatError": "LDAP group name must start with a letter and end with a letter or number. It can only contain letters, numbers, and hyphens.",
       "descriptionTitle": "Description",
       "courseDescriptionPlaceholder": "Say something about this group",
       "linkTitle": "Link Resources",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -250,7 +250,7 @@
       "courseTitlePlaceholder": "為你的新群組取個名稱",
       "ldapGroupNameTitle": "LDAP 群組名稱",
       "ldapGroupNamePlaceholder": "LDAP 中的群組名稱",
-      "ldapGroupNameFormatError": "LDAP 群組名稱必須以字母開頭，以字母或數字結尾，且僅能包含字母、數字、連字號(-)與空格。",
+      "ldapGroupNameFormatError": "LDAP 群組名稱必須以字母開頭，以字母或數字結尾，且僅能包含字母、數字與連字號(-)。",
       "descriptionTitle": "描述",
       "courseDescriptionPlaceholder": "介紹一下這個群組",
       "linkTitle": "連結資源",

--- a/src/pages/group/CreateGroup.tsx
+++ b/src/pages/group/CreateGroup.tsx
@@ -112,7 +112,7 @@ export default function AddGroupPage() {
   }
 
   function verifyLdapGroupName(ldapGroupName: string): boolean {
-    if (/^[a-zA-Z]([a-zA-Z0-9- ]*[a-zA-Z0-9])?$/.test(ldapGroupName)) {
+    if (/^[a-zA-Z]([a-zA-Z0-9-]*[a-zA-Z0-9])?$/.test(ldapGroupName)) {
       return true;
     }
     return false;


### PR DESCRIPTION
## Type of changes

- Fix

## Purpose

- We should block LDAP group names with spaces when creating LDAP group.


