### PR TITLE
Enable GitHub action to insert preview website URL in PR description

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,3 +12,6 @@
 ## Additional Information
 
 <!-- Optional: Add any other information that would be helpful for the reviewer. Like detail spec, decisions, trade-offs, links, etc. -->
+
+<!-- GitHub Action will insert the preview url in the preview-url tag -->
+<!-- preview-url -->

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -168,3 +168,26 @@ jobs:
               }
             }
           }'
+
+      # the preview URL format in defined in Clustron document "Clustron Project Workflow" https://www.notion.so/sdc-nycu/Clustron-Project-Workflow-3497dadd804080bbac89d959c1beae0d?source=copy_link
+      - name: Update PR description with preview URL
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const previewUrl = `https://pr-${pr.number}.clustron.sdc.nycu.club`;
+            const marker = '<!-- preview-url -->';
+
+            const currentBody = pr.body || '';
+            const previewSection = `${marker}\n## Preview Environment\n${previewUrl}`;
+
+            const newBody = currentBody.includes(marker)
+              ? currentBody.replace(/<!--\s*preview-url\s*-->[\s\S]*/, previewSection)
+              : `${currentBody}\n\n${previewSection}`;
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              body: newBody,
+            });

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -170,6 +170,14 @@ jobs:
           }'
 
       # the preview URL format in defined in Clustron document "Clustron Project Workflow" https://www.notion.so/sdc-nycu/Clustron-Project-Workflow-3497dadd804080bbac89d959c1beae0d?source=copy_link
+
+  Update-PR-Description:
+    name: Update PR description with preview URL
+    needs: Deploy
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
       - name: Update PR description with preview URL
         uses: actions/github-script@v8
         with:


### PR DESCRIPTION
## Type of changes

- CI

## Purpose

- Enable GitHub action to insert the preview website URL in the PR description.
- Make it convenient for the reviewer to visit the preview of a certain PR without memorizing the preview URL format.

<!-- Provide a brief description of the changes made in this pull request. -->

## Additional Information

The URL will be set in the preview URL comment tag.


<!-- preview-url -->
## Preview Environment
https://pr-150.clustron.sdc.nycu.club