### PR TITLE
Allow eslint to be built in GitHub Action

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,8 +18,13 @@ jobs:
         with:
           node-version: 23
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - name: Install dependencies
-        run: npm install -g pnpm && pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run ESLint
         run: npx eslint .
@@ -36,8 +41,13 @@ jobs:
         with:
           node-version: 23
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - name: Install dependencies
-        run: npm install -g pnpm && pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run Prettier
 
@@ -55,8 +65,13 @@ jobs:
         with:
           node-version: 23
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - name: Install dependencies
-        run: npm install -g pnpm && pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run Tests
         run: npx vitest run --coverage
@@ -76,8 +91,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - name: Install dependencies
-        run: npm install -g pnpm && pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -18,8 +18,13 @@ jobs:
         with:
           node-version: 23
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - name: Install dependencies
-        run: npm install -g pnpm && pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run ESLint
         run: npx eslint .
@@ -36,8 +41,13 @@ jobs:
         with:
           node-version: 23
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - name: Install dependencies
-        run: npm install -g pnpm && pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run Prettier
         run: npx prettier . --check
@@ -54,8 +64,13 @@ jobs:
         with:
           node-version: 23
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - name: Install dependencies
-        run: npm install -g pnpm && pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run Tests
         run: npx vitest run --coverage
@@ -72,8 +87,13 @@ jobs:
         with:
           node-version: 23
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - name: Install dependencies
-        run: npm install -g pnpm && pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build Vite production
         run: pnpm build
@@ -94,8 +114,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - name: Install dependencies
-        run: npm install -g pnpm && pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/stage.yaml
+++ b/.github/workflows/stage.yaml
@@ -18,8 +18,13 @@ jobs:
         with:
           node-version: 23
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - name: Install dependencies
-        run: npm install -g pnpm && pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run ESLint
         run: npx eslint .
@@ -36,8 +41,13 @@ jobs:
         with:
           node-version: 23
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - name: Install dependencies
-        run: npm install -g pnpm && pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run Prettier
 
@@ -55,8 +65,13 @@ jobs:
         with:
           node-version: 23
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - name: Install dependencies
-        run: npm install -g pnpm && pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run Tests
         run: npx vitest run --coverage
@@ -74,8 +89,13 @@ jobs:
         with:
           node-version: 23
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - name: Install dependencies
-        run: npm install -g pnpm && pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build Vite production
         run: pnpm build
@@ -96,8 +116,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - name: Install dependencies
-        run: npm install -g pnpm && pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
## Type of changes

- Fix
- CI

## Purpose

- Add allowBuilds tag in pnpm-workspace.yaml so that esbuild can be built correctly in GitHub Action
- Resolve the issue that errors when building esbuild prevent CI from installing the necessary dependencies.

<!-- Provide a brief description of the changes made in this pull request. -->

## Additional Information
The cause:
pnpm v10 introduced a security feature (released January 2025): dependency lifecycle scripts (postinstall scripts) are no longer executed during installation by default. esbuild uses a postinstall script to download its native binary, so it gets blocked.

<!-- Optional: Add any other information that would be helpful for the reviewer. Like detail spec, decisions, trade-offs, links, etc. -->

<!-- GitHub Action will insert the preview url in the preview-url tag -->
<!-- preview-url -->
## Preview Environment
https://pr-154.clustron.sdc.nycu.club