### PR TITLE
[CLUST-329] Remove sidebar label translation

### DIFF
--- a/src/components/NavTabs.tsx
+++ b/src/components/NavTabs.tsx
@@ -1,7 +1,6 @@
 import { NavLink } from "react-router";
-import { useTranslation } from "react-i18next";
 import ErrorBoundary from "./ErrorBoundary";
-import { NavItem } from "./Sidebar";
+import { type NavItem } from "./Sidebar";
 
 function tabLinkClass(isActive: boolean): string {
   return [
@@ -19,8 +18,6 @@ interface NavTabsProps {
 }
 
 export default function NavTabs({ title, navItems, className }: NavTabsProps) {
-  const { t } = useTranslation();
-
   return (
     <ErrorBoundary>
       <div className={className}>
@@ -33,7 +30,7 @@ export default function NavTabs({ title, navItems, className }: NavTabsProps) {
               end={item.end ?? true}
               className={({ isActive }) => tabLinkClass(isActive)}
             >
-              {t(item.label)}
+              {item.label}
             </NavLink>
           ))}
         </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,4 @@
 import { NavLink } from "react-router";
-import { useTranslation } from "react-i18next";
 import ErrorBoundary from "./ErrorBoundary";
 import {
   Tooltip,
@@ -53,8 +52,6 @@ interface SideBarProps {
 }
 
 export default function SideBar({ title, navItems, className }: SideBarProps) {
-  const { t } = useTranslation();
-
   const displayTitle = truncateMiddle(title, 15);
 
   return (
@@ -82,7 +79,7 @@ export default function SideBar({ title, navItems, className }: SideBarProps) {
                 end={item.end ?? true}
                 className={({ isActive }) => navLinkClass(isActive)}
               >
-                {t(item.label)}
+                {item.label}
               </NavLink>
             </li>
           ))}

--- a/src/pages/layouts/AdminLayout.tsx
+++ b/src/pages/layouts/AdminLayout.tsx
@@ -31,11 +31,11 @@ export default function AdminLayout() {
   const adminNavItems: NavItem[] = [
     {
       to: "/admin/users",
-      label: "adminSidebar.userConfigLink",
+      label: t("adminSidebar.userConfigLink"),
     },
     {
       to: "/admin/config",
-      label: "adminSidebar.roleAccessConfigLink",
+      label: t("adminSidebar.roleAccessConfigLink"),
     },
   ];
   if (role !== "admin") return null;

--- a/src/pages/layouts/GroupLayout.tsx
+++ b/src/pages/layouts/GroupLayout.tsx
@@ -1,6 +1,6 @@
 import { Outlet, useParams, Navigate, useLocation } from "react-router";
 import { useGetGroupById } from "@/hooks/useGetGroupById";
-import SideBar, { NavItem } from "@/components/Sidebar";
+import SideBar, { type NavItem } from "@/components/Sidebar";
 import NavTabs from "@/components/NavTabs";
 import { useTranslation } from "react-i18next";
 import ErrorBoundary from "@/components/ErrorBoundary";
@@ -21,18 +21,18 @@ export default function GroupLayout() {
   const groupNavItems: NavItem[] = [
     {
       to: `/groups/${id}/`,
-      label: "groupComponents.groupSideBar.overview",
+      label: t("groupComponents.groupSideBar.overview"),
     },
     {
       to: `/groups/${id}/settings`,
-      label: "groupComponents.groupSideBar.groupSettings",
+      label: t("groupComponents.groupSideBar.groupSettings"),
     },
   ];
 
   const readonlyNavItems: NavItem[] = [
     {
       to: `/groups/${id}/`,
-      label: "groupComponents.groupSideBar.overview",
+      label: t("groupComponents.groupSideBar.overview"),
     },
   ];
 

--- a/src/pages/layouts/JobLayout.tsx
+++ b/src/pages/layouts/JobLayout.tsx
@@ -1,6 +1,6 @@
 import { Outlet } from "react-router";
 import { useTranslation } from "react-i18next";
-import SideBar, { NavItem } from "@/components/Sidebar";
+import SideBar, { type NavItem } from "@/components/Sidebar";
 import ErrorBoundary from "@/components/ErrorBoundary";
 
 export default function JobLayout() {

--- a/src/pages/layouts/SettingLayout.tsx
+++ b/src/pages/layouts/SettingLayout.tsx
@@ -1,6 +1,6 @@
 import { Outlet } from "react-router";
 import { useTranslation } from "react-i18next";
-import SideBar, { NavItem } from "@/components/Sidebar";
+import SideBar, { type NavItem } from "@/components/Sidebar";
 import NavTabs from "@/components/NavTabs";
 import ErrorBoundary from "@/components/ErrorBoundary";
 
@@ -10,12 +10,12 @@ export default function SettingLayout() {
   const settingNavItems: NavItem[] = [
     {
       to: "/setting/general",
-      label: "settingSideBar.GeneralNavLink",
+      label: t("settingSideBar.GeneralNavLink"),
       end: true,
     },
     {
       to: "/setting/ssh",
-      label: "settingSideBar.SSHNavLink",
+      label: t("settingSideBar.SSHNavLink"),
       end: false,
     },
   ];


### PR DESCRIPTION
## Type of changes

- Refactor

## Purpose

- Remove label translation from the SideBar component.
- Let parent layout components pass already-translated labels to SideBar.
- Update AdminLayout, GroupLayout, and SettingLayout to translate nav item labels before passing them in.

## Additional Information

- SideBar now directly renders `item.label`.
- JobLayout already passed translated labels, so only the type import was updated.